### PR TITLE
Make code ready for re-pulling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ out/
 .gradle/
 docker/users
 docker/source-fitbit.properties
+docker/rest-source-authorizer/etc/rest_source_clients_configs.yml

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ your Fitbit App client ID and client secret. The following tables shows the poss
 <tr>
 <td>fitbit.api.intraday</td></td><td>Set to true if the client has permissions to Fitbit Intraday API, false otherwise.</td></td><td>boolean</td></td><td>true</td></td><td></td></td><td>medium</td></td></tr>
 <tr>
-<td>fitbit.user.repository.class</td></td><td>Class for managing users and authentication.</td></td><td>class</td></td><td>org.radarbase.connect.rest.fitbit.user.YamlUserRepository</td></td><td>Class extending org.radarbase.connect.rest.fitbit.user.UserRepository</td></td><td>medium</td></td></tr>
+<td>fitbit.user.repository.classes</td></td><td>Class(es) for managing users and authentication. Comma separate for using multiple repositories</td></td><td>list</td></td><td>org.radarbase.connect.rest.fitbit.user.YamlUserRepository</td></td><td>Classes extending org.radarbase.connect.rest.fitbit.user.UserRepository</td></td><td>medium</td></td></tr>
 <tr>
 <td>fitbit.user.dir</td></td><td>Directory containing Fitbit user information and credentials. Only used if a file-based user repository is configured.</td></td><td>string</td></td><td>/var/lib/kafka-connect-fitbit-source/users</td></td><td></td></td><td>low</td></td></tr>
 <tr>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,6 +163,8 @@ services:
       - kafka-2
       - kafka-3
       - schema-registry-1
+    networks:
+      - default
     environment:
       CONNECT_BOOTSTRAP_SERVERS: PLAINTEXT://kafka-1:9092,PLAINTEXT://kafka-2:9092,PLAINTEXT://kafka-3:9092
       CONNECT_REST_PORT: 8083
@@ -181,5 +183,6 @@ services:
       CONNECT_ZOOKEEPER_CONNECT: zookeeper-1:2181,zookeeper-2:2181,zookeeper-3:2181
       CONNECTOR_PROPERTY_FILE_PREFIX: "source-fitbit"
       KAFKA_HEAP_OPTS: "-Xms256m -Xmx768m"
+      CONNECT_LOG4J_ROOT_LOGLEVEL: DEBUG
       KAFKA_BROKERS: 3
       CONNECT_LOG4J_LOGGERS: "org.reflections=ERROR"

--- a/docker/source-fitbit.properties.template
+++ b/docker/source-fitbit.properties.template
@@ -7,5 +7,5 @@ rest.source.request.generator.class=org.radarbase.connect.rest.fitbit.request.Fi
 fitbit.api.client=?
 fitbit.api.secret=?
 fitbit.max.users.per.poll=10
-fitbit.user.repository.class=org.radarbase.connect.rest.fitbit.user.ServiceUserRepository
-fitbit.user.repository.url=http://radar-device-auth-backend:8080/
+fitbit.user.repository.classes=org.radarbase.connect.rest.fitbit.user.YamlUserRepository,org.radarbase.connect.rest.fitbit.user.ServiceUserRepository
+fitbit.user.repository.url=http://localhost:8080/

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/request/FitbitRequestGenerator.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/request/FitbitRequestGenerator.java
@@ -23,12 +23,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.confluent.connect.avro.AvroData;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import okhttp3.OkHttpClient;
@@ -58,7 +53,7 @@ public class FitbitRequestGenerator extends RequestGeneratorRouter {
 
   private OkHttpClient baseClient;
   private final Map<String, OkHttpClient> clients;
-  private UserRepository userRepository;
+  private List<UserRepository> userRepositories;
   private List<RequestRoute> routes;
 
   public FitbitRequestGenerator() {
@@ -75,7 +70,7 @@ public class FitbitRequestGenerator extends RequestGeneratorRouter {
     FitbitRestSourceConnectorConfig fitbitConfig = (FitbitRestSourceConnectorConfig) config;
     this.baseClient = new OkHttpClient();
 
-    this.userRepository = fitbitConfig.getUserRepository();
+    this.userRepositories = fitbitConfig.getUserRepositories();
     this.routes = getRoutes(fitbitConfig);
 
     super.initialize(config);
@@ -83,27 +78,34 @@ public class FitbitRequestGenerator extends RequestGeneratorRouter {
 
   private List<RequestRoute> getRoutes(FitbitRestSourceConnectorConfig config) {
     AvroData avroData = new AvroData(20);
-    List<RequestRoute> localRoutes = new ArrayList<>(5);
-    localRoutes.add(new FitbitSleepRoute(this, userRepository, avroData));
-    localRoutes.add(new FitbitTimeZoneRoute(this, userRepository, avroData));
-    localRoutes.add(new FitbitActivityLogRoute(this, userRepository, avroData));
-    if (config.hasIntradayAccess()) {
-      localRoutes.add(new FitbitIntradayStepsRoute(this, userRepository, avroData));
-      localRoutes.add(new FitbitIntradayHeartRateRoute(this, userRepository, avroData));
+    List<RequestRoute> localRoutes = new ArrayList<>(5 * userRepositories.size());
+    for(UserRepository userRepository : userRepositories) {
+      localRoutes.add(new FitbitSleepRoute(this, userRepository, avroData));
+      localRoutes.add(new FitbitTimeZoneRoute(this, userRepository, avroData));
+      localRoutes.add(new FitbitActivityLogRoute(this, userRepository, avroData));
+      if (config.hasIntradayAccess()) {
+        localRoutes.add(new FitbitIntradayStepsRoute(this, userRepository, avroData));
+        localRoutes.add(new FitbitIntradayHeartRateRoute(this, userRepository, avroData));
+      }
     }
     return localRoutes;
   }
 
-  public OkHttpClient getClient(User user) {
+  public OkHttpClient getClient(User user, UserRepository userRepository) {
+
     return clients.computeIfAbsent(user.getId(), u -> baseClient.newBuilder()
-          .authenticator(new TokenAuthenticator(user, userRepository))
-          .build());
+        .authenticator(new TokenAuthenticator(user, userRepository))
+        .build());
   }
 
   public Map<String, Map<String, Object>> getPartitions(String route) {
     try {
-      return userRepository.stream()
-          .collect(Collectors.toMap(User::getId, u -> getPartition(route, u)));
+      Map<String, Map<String, Object>> partitions = new HashMap<>();
+      for(UserRepository userRepository : userRepositories) {
+        partitions.putAll(userRepository.stream()
+            .collect(Collectors.toMap(User::getId, u -> getPartition(route, u))));
+      }
+      return partitions;
     } catch (IOException e) {
       logger.warn("Failed to initialize user partitions for route {}: {}", route, e.toString());
       return Collections.emptyMap();

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitPollingRoute.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitPollingRoute.java
@@ -31,12 +31,7 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAmount;
-import java.util.AbstractMap;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -220,7 +215,7 @@ public abstract class FitbitPollingRoute implements PollingRequestRoute {
           .header("Authorization", "Bearer " + userRepository.getAccessToken(user))
           .build();
       return new FitbitRestRequest(this, request, user, getPartition(user),
-          generator.getClient(user), dateRange,
+          generator.getClient(user, userRepository), dateRange,
           req -> !tooManyRequestsForUser.contains(((FitbitRestRequest)req).getUser()));
     } catch (NotAuthorizedException | IOException ex) {
       logger.warn("User {} does not have a configured access token: {}. Skipping.",


### PR DESCRIPTION
From original PR #37 from @yatharthranjan. I'm sorry I responded too late to the PR, but some fixes should be made before this can be merged.
1. Please follow google style guidelines
2. Try to avoid appending to collections inside a stream
3. There is already a usable paradigm for managing users, the UserRepository is the abstraction of choice for this. That can be used for resolution of what authentication to use, how to update users, and how to handle duplication. Possibly, user repositories need to get an identifier to accompany each user, so that it is clear what user repository a user originated from.