### PR TITLE
Release 0.2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ your Fitbit App client ID and client secret. The following tables shows the poss
 <tr>
 <td>fitbit.api.secret</td></td><td>Secret for the Fitbit API client set in fitbit.api.client.</td></td><td>password</td></td><td></td></td><td></td></td><td>high</td></td></tr>
 <tr>
-<td>fitbit.api.intraday</td></td><td>Set to true if the client has permissions to Fitbit Intraday API, false otherwise.</td></td><td>boolean</td></td><td>true</td></td><td></td></td><td>medium</td></td></tr>
+<td>fitbit.user.poll.interval</td></td><td>Polling interval per Fitbit user per request route in seconds.</td></td><td>int</td></td><td>150</td></td><td></td></td><td>medium</td></td></tr>
+<tr>
+<td>fitbit.api.intraday</td></td><td>Set to true if the client has permissions to Fitbit Intraday API, false otherwise.</td></td><td>boolean</td></td><td>false</td></td><td></td></td><td>medium</td></td></tr>
 <tr>
 <td>fitbit.user.repository.class</td></td><td>Class for managing users and authentication.</td></td><td>class</td></td><td>org.radarbase.connect.rest.fitbit.user.YamlUserRepository</td></td><td>Class extending org.radarbase.connect.rest.fitbit.user.UserRepository</td></td><td>medium</td></td></tr>
 <tr>

--- a/build.gradle
+++ b/build.gradle
@@ -10,8 +10,8 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'java-library'
 
-    group = 'org.radarcns'
-    version = '0.2.3-SNAPSHOT'
+    group = 'org.radarbase'
+    version = '0.2.3'
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ subprojects {
     apply plugin: 'java-library'
 
     group = 'org.radarcns'
-    version = '0.2.2'
+    version = '0.2.3-SNAPSHOT'
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8

--- a/kafka-connect-fitbit-source/build.gradle
+++ b/kafka-connect-fitbit-source/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api project(':kafka-connect-rest-source')
     api group: 'io.confluent', name: 'kafka-connect-avro-converter', version: confluentVersion
-    api group: 'org.radarcns', name: 'radar-schemas-commons', version: '0.5.0'
+    api group: 'org.radarcns', name: 'radar-schemas-commons', version: '0.5.1'
 
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: jacksonVersion
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: jacksonVersion

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/FitbitRestSourceConnectorConfig.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/FitbitRestSourceConnectorConfig.java
@@ -70,6 +70,14 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
   private static final boolean FITBIT_API_INTRADAY_ACCESS_DEFAULT = false;
   private static final String FITBIT_API_INTRADAY_ACCESS_DISPLAY = "Is Fitbit Intraday API available?";
 
+  public static final String FITBIT_USER_POLL_INTERVAL = "fitbit.user.poll.interval";
+  private static final String FITBIT_USER_POLL_INTERVAL_DOC = "Polling interval per Fitbit user per request route in seconds.";
+  // 150 requests per hour -> 2.5 per minute. There are currently 5 paths, that limits us to 1
+  // call per route per 2 minutes.
+  private static final int FITBIT_USER_POLL_INTERVAL_DEFAULT = 150;
+  private static final String FITBIT_USER_POLL_INTERVAL_DISPLAY = "Per-user per-route polling interval.";
+
+
   public static final String FITBIT_USER_CREDENTIALS_DIR_CONFIG = "fitbit.user.dir";
   private static final String FITBIT_USER_CREDENTIALS_DIR_DOC = "Directory containing Fitbit user information and credentials. Only used if a file-based user repository is configured.";
   private static final String FITBIT_USER_CREDENTIALS_DIR_DISPLAY = "User directory";
@@ -178,9 +186,19 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
             Width.SHORT,
             FITBIT_API_SECRET_DISPLAY)
 
+        .define(FITBIT_USER_POLL_INTERVAL,
+            Type.INT,
+            FITBIT_USER_POLL_INTERVAL_DEFAULT,
+            Importance.MEDIUM,
+            FITBIT_USER_POLL_INTERVAL_DOC,
+            group,
+            ++orderInGroup,
+            Width.SHORT,
+            FITBIT_USER_POLL_INTERVAL_DISPLAY)
+
         .define(FITBIT_API_INTRADAY_ACCESS_CONFIG,
             Type.BOOLEAN,
-            true,
+            FITBIT_API_INTRADAY_ACCESS_DEFAULT,
             Importance.MEDIUM,
             FITBIT_API_INTRADAY_ACCESS_DOC,
             group,
@@ -351,5 +369,13 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
 
   public boolean hasIntradayAccess() {
     return getBoolean(FITBIT_API_INTRADAY_ACCESS_CONFIG);
+  }
+
+  public Duration getPollIntervalPerUser() {
+    return Duration.ofSeconds(getInt(FITBIT_USER_POLL_INTERVAL));
+  }
+
+  public Duration getTooManyRequestsCooldownInterval() {
+    return Duration.ofHours(1);
   }
 }

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitIntradayHeartRateRoute.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitIntradayHeartRateRoute.java
@@ -29,12 +29,11 @@ import org.radarbase.connect.rest.fitbit.user.User;
 import org.radarbase.connect.rest.fitbit.user.UserRepository;
 
 public class FitbitIntradayHeartRateRoute extends FitbitPollingRoute {
-  private static final String ROUTE_NAME = "heart_rate";
   private final FitbitIntradayHeartRateAvroConverter converter;
 
   public FitbitIntradayHeartRateRoute(FitbitRequestGenerator generator,
       UserRepository userRepository, AvroData avroData) {
-    super(generator, userRepository, ROUTE_NAME);
+    super(generator, userRepository, "heart_rate");
     this.converter = new FitbitIntradayHeartRateAvroConverter(avroData);
   }
 

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/ServiceUserRepository.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/ServiceUserRepository.java
@@ -90,12 +90,12 @@ public class ServiceUserRepository implements UserRepository {
     Instant now = Instant.now();
     if (!now.isAfter(nextFetchTime)
         || !nextFetch.compareAndSet(nextFetchTime, now.plus(FETCH_THRESHOLD))) {
-      logger.info("Providing cached user information...");
+      logger.debug("Providing cached user information...");
       return timedCachedUsers.stream();
     }
 
     logger.info("Requesting user information from webservice");
-    Request request = requestFor("users" + "?source-type=FitBit").build();
+    Request request = requestFor("users?source-type=FitBit").build();
     this.timedCachedUsers =
         this.<Users>makeRequest(request, USER_LIST_READER).getUsers().stream()
             .filter(u -> u.isComplete()

--- a/kafka-connect-rest-source/src/main/java/org/radarbase/connect/rest/RestSourceConnectorConfig.java
+++ b/kafka-connect-rest-source/src/main/java/org/radarbase/connect/rest/RestSourceConnectorConfig.java
@@ -214,12 +214,4 @@ public class RestSourceConnectorConfig extends AbstractConfig {
     requestGenerator.initialize(this);
     return requestGenerator;
   }
-
-  public Duration getPollIntervalPerUser() {
-    return Duration.ofMinutes(30);
-  }
-
-  public Duration getTooManyRequestsCooldownInterval() {
-    return Duration.ofHours(1);
-  }
 }

--- a/kafka-connect-rest-source/src/main/java/org/radarbase/connect/rest/RestSourceTask.java
+++ b/kafka-connect-rest-source/src/main/java/org/radarbase/connect/rest/RestSourceTask.java
@@ -76,12 +76,15 @@ public class RestSourceTask extends SourceTask {
       }
 
       Iterator<? extends RestRequest> requestIterator = requestGenerator.requests()
-          .filter(RestRequest::isStillValid)
           .iterator();
 
 
       while (requests.isEmpty() && requestIterator.hasNext()) {
         RestRequest request = requestIterator.next();
+
+        if (!request.isStillValid()) {
+          continue;
+        }
 
         logger.info("Requesting {}", request.getRequest().url());
         requestsGenerated++;

--- a/kafka-connect-rest-source/src/main/java/org/radarbase/connect/rest/request/RestRequest.java
+++ b/kafka-connect-rest-source/src/main/java/org/radarbase/connect/rest/request/RestRequest.java
@@ -72,7 +72,7 @@ public class RestRequest {
 
   /**
    * Handle the request using the internal client, using the request route converter.
-   * @return stream of resulting source records, or {@code null} if the response was not successful.
+   * @return stream of resulting source records.
    * @throws IOException if making or parsing the request failed.
    */
   public Stream<SourceRecord> handleRequest() throws IOException {
@@ -83,7 +83,7 @@ public class RestRequest {
     try (Response response = client.newCall(request).execute()) {
       if (!response.isSuccessful()) {
         route.requestFailed(this, response);
-        return null;
+        return Stream.empty();
       }
 
       Collection<SourceRecord> records = route.converter().convert(this, response);

--- a/scripts/REDCAP-FITBIT-AUTH-AUTO/redcap-fitbit-auth.py
+++ b/scripts/REDCAP-FITBIT-AUTH-AUTO/redcap-fitbit-auth.py
@@ -149,7 +149,7 @@ def format_file_name(name, extension):
 
 def register_users():
     with open("config.yml", "r") as fi:
-        config = yaml.load(fi)
+        config = yaml.load(fi, Loader=yaml.SafeLoader)
 
     output_data_dict = []
     # to generalize the storeage replace this getRedcapRecords with any

--- a/scripts/REDCAP-FITBIT-AUTH-AUTO/requirements.txt
+++ b/scripts/REDCAP-FITBIT-AUTH-AUTO/requirements.txt
@@ -2,8 +2,8 @@ certifi==2018.10.15
 chardet==3.0.4
 idna==2.7
 PyCap==1.0.2
-PyYAML==3.13
-requests==2.20.0
+PyYAML==5.1.1
+requests==2.22.0
 selenium==3.14.1
 semantic-version==2.3.1
-urllib3==1.24
+urllib3==1.25.3


### PR DESCRIPTION
Changes since version 0.2.2:
- Reverts bug introduced in 0.2.2: replace `findFirst` to run request with an `Iterator` after which to run the request. By using calls with side-effects in streams, Java streams was preloading a lot of URLs without evaluating the findFirst and data was lost in that way. 
- Fix security issues
- Make polling time per user route configurable