### PR TITLE
Intraday activity and calories

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ your Fitbit App client ID and client secret. The following tables shows the poss
 <tr>
 <td>fitbit.api.secret</td></td><td>Secret for the Fitbit API client set in fitbit.api.client.</td></td><td>password</td></td><td></td></td><td></td></td><td>high</td></td></tr>
 <tr>
-<td>fitbit.api.intraday</td></td><td>Set to true if the client has permissions to Fitbit Intraday API, false otherwise.</td></td><td>boolean</td></td><td>true</td></td><td></td></td><td>medium</td></td></tr>
+<td>fitbit.api.intraday</td></td><td>Set to true if the client has permissions to Fitbit Intraday API, false otherwise.</td></td><td>boolean</td></td><td>false</td></td><td></td></td><td>medium</td></td></tr>
 <tr>
 <td>fitbit.user.repository.class</td></td><td>Class for managing users and authentication.</td></td><td>class</td></td><td>org.radarbase.connect.rest.fitbit.user.YamlUserRepository</td></td><td>Class extending org.radarbase.connect.rest.fitbit.user.UserRepository</td></td><td>medium</td></td></tr>
 <tr>
@@ -72,6 +72,8 @@ your Fitbit App client ID and client secret. The following tables shows the poss
 <td>fitbit.time.zone.topic</td></td><td>Topic for Fitbit profile time zone</td></td><td>string</td></td><td>connect_fitbit_time_zone</td></td><td>non-empty string without control characters</td></td><td>low</td></td></tr>
 <tr>
 <td>fitbit.activity.log.topic</td></td><td>Topic for Fitbit activity log.</td></td><td>string</td></td><td>connect_fitbit_activity_log</td></td><td>non-empty string without control characters</td></td><td>low</td></td></tr>
+<tr>
+<td>fitbit.intraday.calories.topic</td></td><td>Topic for Fitbit intraday calories</td></td><td>string</td></td><td>connect_fitbit_intraday_calories</td></td><td>non-empty string without control characters</td></td><td>low</td></td></tr>
 </tbody></table>
 
 Now you can run a full Kafka stack using

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ subprojects {
         maven { url "http://repo.maven.apache.org/maven2" }
         jcenter()
         maven { url  'http://oss.jfrog.org/artifactory/oss-snapshot-local/' }
+      mavenLocal()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,6 @@ subprojects {
         maven { url "http://repo.maven.apache.org/maven2" }
         jcenter()
         maven { url  'http://oss.jfrog.org/artifactory/oss-snapshot-local/' }
-      mavenLocal()
     }
 }
 

--- a/kafka-connect-fitbit-source/build.gradle
+++ b/kafka-connect-fitbit-source/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api project(':kafka-connect-rest-source')
     api group: 'io.confluent', name: 'kafka-connect-avro-converter', version: confluentVersion
-    api group: 'org.radarcns', name: 'radar-schemas-commons', version: '0.5.0'
+    api group: 'org.radarcns', name: 'radar-schemas-commons', version: '0.5.4-SNAPSHOT'
 
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: jacksonVersion
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: jacksonVersion

--- a/kafka-connect-fitbit-source/build.gradle
+++ b/kafka-connect-fitbit-source/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     api project(':kafka-connect-rest-source')
     api group: 'io.confluent', name: 'kafka-connect-avro-converter', version: confluentVersion
-    api group: 'org.radarcns', name: 'radar-schemas-commons', version: '0.5.4-SNAPSHOT'
+    api group: 'org.radarcns', name: 'radar-schemas-commons', version: '0.5.3'
 
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: jacksonVersion
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: jacksonVersion

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/FitbitRestSourceConnectorConfig.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/FitbitRestSourceConnectorConfig.java
@@ -118,6 +118,11 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
   private static final String FITBIT_ACTIVITY_LOG_TOPIC_DEFAULT = "connect_fitbit_activity_log";
   private static final String FITBIT_ACTIVITY_LOG_TOPIC_DISPLAY = "Activity log topic";
 
+  private static final String FITBIT_INTRADAY_CALORIES_TOPIC_CONFIG = "fitbit.intraday.calories.topic";
+  private static final String FITBIT_INTRADAY_CALORIES_TOPIC_DOC = "Topic for Fitbit intraday calories";
+  private static final String FITBIT_INTRADAY_CALORIES_TOPIC_DISPLAY = "Intraday calories topic";
+  private static final String FITBIT_INTRADAY_CALORIES_TOPIC_DEFAULT = "connect_fitbit_calories_steps";
+
   private final UserRepository userRepository;
   private final Headers clientCredentials;
 
@@ -302,6 +307,17 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
             ++orderInGroup,
             Width.SHORT,
             FITBIT_ACTIVITY_LOG_TOPIC_DISPLAY)
+
+        .define(FITBIT_INTRADAY_CALORIES_TOPIC_CONFIG,
+            Type.STRING,
+            FITBIT_INTRADAY_CALORIES_TOPIC_DEFAULT,
+            nonControlChar,
+            Importance.LOW,
+            FITBIT_INTRADAY_CALORIES_TOPIC_DOC,
+            group,
+            ++orderInGroup,
+            Width.SHORT,
+            FITBIT_INTRADAY_CALORIES_TOPIC_DISPLAY)
         ;
   }
 
@@ -377,5 +393,9 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
 
   public Duration getTooManyRequestsCooldownInterval() {
     return Duration.ofHours(1);
+  }
+
+  public String getFitbitIntradayCaloriesTopic() {
+    return getString(FITBIT_INTRADAY_CALORIES_TOPIC_CONFIG);
   }
 }

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/FitbitRestSourceConnectorConfig.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/FitbitRestSourceConnectorConfig.java
@@ -121,7 +121,7 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
   private static final String FITBIT_INTRADAY_CALORIES_TOPIC_CONFIG = "fitbit.intraday.calories.topic";
   private static final String FITBIT_INTRADAY_CALORIES_TOPIC_DOC = "Topic for Fitbit intraday calories";
   private static final String FITBIT_INTRADAY_CALORIES_TOPIC_DISPLAY = "Intraday calories topic";
-  private static final String FITBIT_INTRADAY_CALORIES_TOPIC_DEFAULT = "connect_fitbit_calories_steps";
+  private static final String FITBIT_INTRADAY_CALORIES_TOPIC_DEFAULT = "connect_fitbit_intraday_calories";
 
   private final UserRepository userRepository;
   private final Headers clientCredentials;

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/converter/FitbitIntradayCaloriesAvroConverter.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/converter/FitbitIntradayCaloriesAvroConverter.java
@@ -1,0 +1,79 @@
+package org.radarbase.connect.rest.fitbit.converter;
+
+import static org.radarbase.connect.rest.util.ThrowingFunction.tryOrNull;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import io.confluent.connect.avro.AvroData;
+import java.time.Instant;
+import java.time.LocalTime;
+import java.time.ZonedDateTime;
+import java.util.stream.Stream;
+import org.radarbase.connect.rest.RestSourceConnectorConfig;
+import org.radarbase.connect.rest.fitbit.FitbitRestSourceConnectorConfig;
+import org.radarbase.connect.rest.fitbit.request.FitbitRestRequest;
+import org.radarcns.connector.fitbit.FitbitIntradayCalories;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class FitbitIntradayCaloriesAvroConverter extends FitbitAvroConverter {
+
+  private static final Logger logger =
+      LoggerFactory.getLogger(FitbitIntradayCaloriesAvroConverter.class);
+
+  private String caloriesTopic;
+
+  public FitbitIntradayCaloriesAvroConverter(AvroData avroData) {
+    super(avroData);
+  }
+
+  @Override
+  protected Stream<TopicData> processRecords(
+      FitbitRestRequest request, JsonNode root, double timeReceived) {
+    JsonNode intraday = root.get("activities-calories-intraday");
+    if (intraday == null) {
+      return Stream.empty();
+    }
+
+    JsonNode dataset = intraday.get("dataset");
+    if (dataset == null) {
+      return Stream.empty();
+    }
+
+    int interval = getRecordInterval(intraday, 60);
+
+    // Used as the date to convert the local times in the dataset to absolute times.
+    ZonedDateTime startDate = request.getDateRange().end();
+
+    return iterableToStream(dataset)
+        .map(
+            tryOrNull(
+                activity -> {
+                  Instant time =
+                      startDate.with(LocalTime.parse(activity.get("time").asText())).toInstant();
+
+                  FitbitIntradayCalories steps =
+                      new FitbitIntradayCalories(
+                          time.toEpochMilli() / 1000d,
+                          timeReceived,
+                          interval,
+                          activity.get("value").asDouble(),
+                          activity.get("level").asInt(),
+                          activity.get("mets").asInt());
+
+                  return new TopicData(time, caloriesTopic, steps);
+                },
+                (a, ex) ->
+                    logger.warn(
+                        "Failed to convert steps from request {} of user {}, {}",
+                        request.getRequest().url(),
+                        request.getUser(),
+                        a,
+                        ex)));
+  }
+
+  @Override
+  public void initialize(RestSourceConnectorConfig config) {
+    caloriesTopic = ((FitbitRestSourceConnectorConfig) config).getFitbitIntradayCaloriesTopic();
+    logger.info("Using calories topic {}", caloriesTopic);
+  }
+}

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/converter/FitbitIntradayCaloriesAvroConverter.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/converter/FitbitIntradayCaloriesAvroConverter.java
@@ -51,7 +51,7 @@ public class FitbitIntradayCaloriesAvroConverter extends FitbitAvroConverter {
                   Instant time =
                       startDate.with(LocalTime.parse(activity.get("time").asText())).toInstant();
 
-                  FitbitIntradayCalories steps =
+                  FitbitIntradayCalories calories =
                       new FitbitIntradayCalories(
                           time.toEpochMilli() / 1000d,
                           timeReceived,
@@ -60,7 +60,7 @@ public class FitbitIntradayCaloriesAvroConverter extends FitbitAvroConverter {
                           activity.get("level").asInt(),
                           activity.get("mets").asDouble());
 
-                  return new TopicData(time, caloriesTopic, steps);
+                  return new TopicData(time, caloriesTopic, calories);
                 },
                 (a, ex) ->
                     logger.warn(

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/converter/FitbitIntradayCaloriesAvroConverter.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/converter/FitbitIntradayCaloriesAvroConverter.java
@@ -64,7 +64,7 @@ public class FitbitIntradayCaloriesAvroConverter extends FitbitAvroConverter {
                 },
                 (a, ex) ->
                     logger.warn(
-                        "Failed to convert steps from request {} of user {}, {}",
+                        "Failed to convert calories from request {} of user {}, {}",
                         request.getRequest().url(),
                         request.getUser(),
                         a,

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/converter/FitbitIntradayCaloriesAvroConverter.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/converter/FitbitIntradayCaloriesAvroConverter.java
@@ -58,7 +58,7 @@ public class FitbitIntradayCaloriesAvroConverter extends FitbitAvroConverter {
                           interval,
                           activity.get("value").asDouble(),
                           activity.get("level").asInt(),
-                          activity.get("mets").asInt());
+                          activity.get("mets").asDouble());
 
                   return new TopicData(time, caloriesTopic, steps);
                 },

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/request/FitbitRequestGenerator.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/request/FitbitRequestGenerator.java
@@ -35,6 +35,7 @@ import okhttp3.OkHttpClient;
 import org.radarbase.connect.rest.RestSourceConnectorConfig;
 import org.radarbase.connect.rest.fitbit.FitbitRestSourceConnectorConfig;
 import org.radarbase.connect.rest.fitbit.route.FitbitActivityLogRoute;
+import org.radarbase.connect.rest.fitbit.route.FitbitIntradayCaloriesRoute;
 import org.radarbase.connect.rest.fitbit.route.FitbitIntradayHeartRateRoute;
 import org.radarbase.connect.rest.fitbit.route.FitbitIntradayStepsRoute;
 import org.radarbase.connect.rest.fitbit.route.FitbitSleepRoute;
@@ -90,6 +91,7 @@ public class FitbitRequestGenerator extends RequestGeneratorRouter {
     if (config.hasIntradayAccess()) {
       localRoutes.add(new FitbitIntradayStepsRoute(this, userRepository, avroData));
       localRoutes.add(new FitbitIntradayHeartRateRoute(this, userRepository, avroData));
+      localRoutes.add(new FitbitIntradayCaloriesRoute(this, userRepository, avroData));
     }
     return localRoutes;
   }

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitIntradayCaloriesRoute.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitIntradayCaloriesRoute.java
@@ -42,6 +42,6 @@ public class FitbitIntradayCaloriesRoute extends FitbitPollingRoute {
 
   @Override
   public PayloadToSourceRecordConverter converter() {
-    return converter();
+    return caloriesAvroConverter;
   }
 }

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitIntradayCaloriesRoute.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitIntradayCaloriesRoute.java
@@ -1,0 +1,47 @@
+package org.radarbase.connect.rest.fitbit.route;
+
+import static java.time.temporal.ChronoUnit.MINUTES;
+
+import io.confluent.connect.avro.AvroData;
+import java.util.stream.Stream;
+import org.radarbase.connect.rest.converter.PayloadToSourceRecordConverter;
+import org.radarbase.connect.rest.fitbit.converter.FitbitIntradayCaloriesAvroConverter;
+import org.radarbase.connect.rest.fitbit.request.FitbitRequestGenerator;
+import org.radarbase.connect.rest.fitbit.request.FitbitRestRequest;
+import org.radarbase.connect.rest.fitbit.user.User;
+import org.radarbase.connect.rest.fitbit.user.UserRepository;
+
+public class FitbitIntradayCaloriesRoute extends FitbitPollingRoute {
+
+  private final FitbitIntradayCaloriesAvroConverter caloriesAvroConverter;
+
+  public FitbitIntradayCaloriesRoute(
+      FitbitRequestGenerator generator, UserRepository userRepository, AvroData avroData) {
+    super(generator, userRepository, "intraday_calories");
+    caloriesAvroConverter = new FitbitIntradayCaloriesAvroConverter(avroData);
+  }
+
+  @Override
+  protected Stream<FitbitRestRequest> createRequests(User user) {
+    return startDateGenerator(this.getOffset(user).plus(ONE_MINUTE).truncatedTo(MINUTES))
+        .map(
+            dateRange ->
+                newRequest(
+                    user,
+                    dateRange,
+                    user.getExternalUserId(),
+                    DATE_FORMAT.format(dateRange.start()),
+                    TIME_FORMAT.format(dateRange.start()),
+                    TIME_FORMAT.format(dateRange.end())));
+  }
+
+  @Override
+  protected String getUrlFormat(String baseUrl) {
+    return baseUrl + "/1/user/%s/activities/calories/date/%s/1d/1min/time/%s/%s.json?timezone=UTC";
+  }
+
+  @Override
+  public PayloadToSourceRecordConverter converter() {
+    return converter();
+  }
+}

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitIntradayStepsRoute.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitIntradayStepsRoute.java
@@ -29,8 +29,6 @@ import org.radarbase.connect.rest.fitbit.user.User;
 import org.radarbase.connect.rest.fitbit.user.UserRepository;
 
 public class FitbitIntradayStepsRoute extends FitbitPollingRoute {
-  private static final TemporalAmount ONE_MINUTE = MINUTES.getDuration();
-
   private final FitbitIntradayStepsAvroConverter converter;
 
   public FitbitIntradayStepsRoute(FitbitRequestGenerator generator,

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitPollingRoute.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitPollingRoute.java
@@ -19,6 +19,7 @@ package org.radarbase.connect.rest.fitbit.route;
 
 import static java.time.ZoneOffset.UTC;
 import static java.time.temporal.ChronoUnit.DAYS;
+import static java.time.temporal.ChronoUnit.MINUTES;
 import static java.time.temporal.ChronoUnit.NANOS;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.radarbase.connect.rest.converter.PayloadToSourceRecordConverter.MIN_INSTANT;
@@ -95,6 +96,7 @@ public abstract class FitbitPollingRoute implements PollingRequestRoute {
   protected static final Duration ONE_DAY = DAYS.getDuration();
   protected static final Duration ONE_NANO = NANOS.getDuration();
   protected static final TemporalAmount ONE_SECOND = SECONDS.getDuration();
+  protected static final TemporalAmount ONE_MINUTE = MINUTES.getDuration();
 
   private static final Logger logger = LoggerFactory.getLogger(FitbitSleepRoute.class);
 


### PR DESCRIPTION
Adds support for `activities/calories` endpoint of the fitbit intraday API. This also includes activity levels and METS.

Closes #25 