### PR TITLE
Use HTTPS in repo urls

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,10 +18,10 @@ subprojects {
 
     repositories {
         mavenCentral()
-        maven { url "http://packages.confluent.io/maven/" }
-        maven { url "http://repo.maven.apache.org/maven2" }
+        maven { url "https://packages.confluent.io/maven/" }
+        maven { url "https://repo.maven.apache.org/maven2" }
         jcenter()
-        maven { url  'http://oss.jfrog.org/artifactory/oss-snapshot-local/' }
+        maven { url  'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
     }
 }
 


### PR DESCRIPTION
maven has stopped supporting HTTP since Jan 15 2020. See https://stackoverflow.com/a/59764670/8175739 for more info