### PR TITLE
Close requests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ subprojects {
     apply plugin: 'java-library'
 
     group = 'org.radarbase'
-    version = '0.3.1'
+    version = '0.3.2-SNAPSHOT'
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/YamlUserRepository.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/YamlUserRepository.java
@@ -276,8 +276,6 @@ public class YamlUserRepository implements UserRepository {
             .build())
         .build();
 
-    Exception exception = null;
-    JsonNode node = null;
     try (Response response = client.newCall(request).execute()) {
       ResponseBody responseBody = response.body();
 

--- a/kafka-connect-rest-source/src/main/java/org/radarbase/connect/rest/request/RestRequest.java
+++ b/kafka-connect-rest-source/src/main/java/org/radarbase/connect/rest/request/RestRequest.java
@@ -80,22 +80,25 @@ public class RestRequest {
       return Stream.empty();
     }
 
+    Collection<SourceRecord> records;
+
     try (Response response = client.newCall(request).execute()) {
       if (!response.isSuccessful()) {
         route.requestFailed(this, response);
         return Stream.empty();
       }
 
-      Collection<SourceRecord> records = route.converter().convert(this, response);
-      if (records.isEmpty()) {
-        route.requestEmpty(this);
-      } else {
-        records.forEach(r -> route.requestSucceeded(this, r));
-      }
-      return records.stream();
+      records = route.converter().convert(this, response);
     } catch (IOException ex) {
       route.requestFailed(this, null);
       throw ex;
     }
+
+    if (records.isEmpty()) {
+      route.requestEmpty(this);
+    } else {
+      records.forEach(r -> route.requestSucceeded(this, r));
+    }
+    return records.stream();
   }
 }


### PR DESCRIPTION
Close requests as soon as possible, to avoid any lingering requests in long-running methods. Intended to address #61.