### PR TITLE
Fix ServiceUserRepository issues

### DIFF
--- a/kafka-connect-fitbit-source/build.gradle.kts
+++ b/kafka-connect-fitbit-source/build.gradle.kts
@@ -15,6 +15,8 @@ dependencies {
     implementation("io.ktor:ktor-client-content-negotiation:${Versions.ktor}")
     implementation("io.ktor:ktor-serialization-jackson:${Versions.ktor}")
     implementation("io.ktor:ktor-client-cio-jvm:${Versions.ktor}")
+    implementation("io.ktor:ktor-serialization-kotlinx-json:${Versions.ktor}")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:${Versions.jackson}")
 
     // Included in connector runtime
     compileOnly("org.apache.kafka:connect-api:${Versions.kafka}")


### PR DESCRIPTION
- Using the `clientCredentials` ktor helper functions from radar-kotlin in the rest-connector causes json deserialization issues
- This adds the fix to ServiceUserRepository to allow deserialization of the repository access token (using json deserialization) and users (using jackson deserialization)