### PR TITLE
Fix Fitbit routes and converter

### DIFF
--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/converter/FitbitIntradayHeartRateVariabilityAvroConverter.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/converter/FitbitIntradayHeartRateVariabilityAvroConverter.java
@@ -73,7 +73,7 @@ public class FitbitIntradayHeartRateVariabilityAvroConverter extends FitbitAvroC
       }
       FitbitIntradayHeartRateVariability fitbitHrv = new FitbitIntradayHeartRateVariability(time.toEpochMilli() / 1000d,
               timeReceived,
-              (float) value.get("dailyRmssd").asDouble(),
+              (float) value.get("rmssd").asDouble(),
               (float) value.get("coverage").asDouble(),
               (float) value.get("hf").asDouble(),
               (float) value.get("lf").asDouble());

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitBreathingRateRoute.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitBreathingRateRoute.java
@@ -46,7 +46,7 @@ public class FitbitBreathingRateRoute extends FitbitPollingRoute {
   protected Stream<FitbitRestRequest> createRequests(User user) {
     return startDateGenerator(getOffset(user).plus(ONE_SECOND).truncatedTo(SECONDS))
         .map(dateRange -> newRequest(user, dateRange,
-            user.getExternalUserId(), DATE_FORMAT.format(dateRange.start())));
+            user.getExternalUserId(), DATE_FORMAT.format(dateRange.start()), DATE_FORMAT.format(dateRange.end())));
   }
 
     /** Limit range to 30 days as documented here: https://dev.fitbit.com/build/reference/web-api/intraday/get-br-intraday-by-interval/ */

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitIntradayHeartRateVariabilityRoute.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitIntradayHeartRateVariabilityRoute.java
@@ -47,7 +47,7 @@ public class FitbitIntradayHeartRateVariabilityRoute extends FitbitPollingRoute 
   protected Stream<FitbitRestRequest> createRequests(User user) {
     return startDateGenerator(getOffset(user).plus(ONE_SECOND).truncatedTo(SECONDS))
         .map(dateRange -> newRequest(user, dateRange,
-            user.getExternalUserId(), DATE_FORMAT.format(dateRange.start())));
+            user.getExternalUserId(), DATE_FORMAT.format(dateRange.start()), DATE_FORMAT.format(dateRange.end())));
   }
 
   /** Limit range to 30 days as documented here: https://dev.fitbit.com/build/reference/web-api/intraday/get-hrv-intraday-by-interval/ */

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitSkinTemperatureRoute.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitSkinTemperatureRoute.java
@@ -46,7 +46,7 @@ public class FitbitSkinTemperatureRoute extends FitbitPollingRoute {
   protected Stream<FitbitRestRequest> createRequests(User user) {
     return startDateGenerator(getOffset(user).plus(ONE_SECOND).truncatedTo(SECONDS))
         .map(dateRange -> newRequest(user, dateRange,
-            user.getExternalUserId(), DATE_FORMAT.format(dateRange.start())));
+            user.getExternalUserId(), DATE_FORMAT.format(dateRange.start()), DATE_FORMAT.format(dateRange.end())));
   }
 
   /** Limit range to 30 days as documented here: https://dev.fitbit.com/build/reference/web-api/temperature/get-temperature-skin-summary-by-interval */


### PR DESCRIPTION
- Previous PR accidentally removed `end date` from request param, added this back
- Update HRV `rmssd` key (In the docs: https://dev.fitbit.com/build/reference/web-api/intraday/get-hrv-intraday-by-interval/ description and response are different keys)