### PR TITLE
Bump radar-schemas to latest version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/oura.yml
+++ b/.github/workflows/oura.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/release-fitbit.yml
+++ b/.github/workflows/release-fitbit.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Gradle cache
         uses: actions/cache@v3

--- a/.github/workflows/release-oura.yml
+++ b/.github/workflows/release-oura.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - name: Gradle cache
         uses: actions/cache@v3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Fitbit in particular. The documentation of the Kafka Connect REST source still n
 ### Installation
 
 This repository relies on a recent version of docker and docker-compose as well as an installation
-of Java 11 or later.
+of Java 17 or later.
 
 ### Usage
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.9.10"
+    kotlin("jvm") version "1.9.22"
 }
 
 repositories {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -2,24 +2,24 @@
 object Versions {
     const val project = "0.4.2-SNAPSHOT"
 
-    const val java = 11
+    const val java = 17
     const val kotlin = "1.9.10"
     const val wrapper = "8.4"
 
-    const val radarCommons = "1.1.1"
-    const val confluent = "7.5.0"
+    const val radarCommons = "1.1.2"
+    const val confluent = "7.6.0"
     const val kafka = "$confluent-ce"
-    const val avro = "1.11.0"
+    const val avro = "1.11.3"
 
     const val managementPortal = "2.0.0"
 
     // From image
-    const val jackson = "2.14.2"
+    const val jackson = "2.16.1"
 
     const val log4j2 = "2.20.0"
     const val slf4j = "2.0.9"
 
-    const val okhttp = "4.11.0"
+    const val okhttp = "4.12.0"
 
     const val firebaseAdmin = "9.1.0"
     const val radarSchemas = "0.8.7-hotfix"
@@ -29,5 +29,5 @@ object Versions {
     const val wiremock = "2.27.2"
     const val mockito = "5.3.1"
 
-    const val kotlinVersion = "1.8.21"
+    const val kotlinVersion = "1.9.10"
 }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -22,7 +22,7 @@ object Versions {
     const val okhttp = "4.11.0"
 
     const val firebaseAdmin = "9.1.0"
-    const val radarSchemas = "0.8.6"
+    const val radarSchemas = "0.8.7-hotfix"
     const val ktor = "2.3.5"
 
     const val junit = "5.9.3"

--- a/kafka-connect-fitbit-source/Dockerfile
+++ b/kafka-connect-fitbit-source/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM gradle:8.4-jdk11 as builder
+FROM --platform=$BUILDPLATFORM gradle:8.4-jdk17 as builder
 
 RUN mkdir /code
 WORKDIR /code

--- a/kafka-connect-oura-source/Dockerfile
+++ b/kafka-connect-oura-source/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM gradle:8.4-jdk11 as builder
+FROM --platform=$BUILDPLATFORM gradle:8.4-jdk17 as builder
 
 RUN mkdir /code
 WORKDIR /code


### PR DESCRIPTION
- Bump radar-schemas to version `0.8.7-hotfix`
- Also bumps other dependencies, updates to Java `17`