### PR TITLE
Update Oura request backoff times

### DIFF
--- a/oura-library/src/main/kotlin/org/radarbase/oura/request/OuraRequestGenerator.kt
+++ b/oura-library/src/main/kotlin/org/radarbase/oura/request/OuraRequestGenerator.kt
@@ -242,8 +242,8 @@ constructor(
         private val BACK_OFF_TIME = Duration.ofMinutes(10L)
         private val ONE_DAY = 1L
         private val TIME_AFTER_REQUEST = Duration.ofDays(30)
-        private val USER_BACK_OFF_TIME = Duration.ofMinutes(2L)
-        private val SUCCESS_BACK_OFF_TIME = Duration.ofSeconds(3L)
+        private val USER_BACK_OFF_TIME = Duration.ofHours(12L)
+        private val SUCCESS_BACK_OFF_TIME = Duration.ofMinutes(1L)
         private val USER_MAX_REQUESTS = 20
         val JSON_FACTORY = JsonFactory()
         val JSON_READER = ObjectMapper(JSON_FACTORY).registerModule(JavaTimeModule()).reader()


### PR DESCRIPTION
- Increases Oura request back off times when there are isses/when the interval between start and end dates is too short since most of the Oura routes have daily intervals 