### PR TITLE
Add test for reauthentication after a failed token request

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,9 @@ max_line_length=100
 
 [*.{gradle,py,kt,kts}]
 indent_size = 4
+
+[*.{kt,kts}]
+ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_allow_trailing_comma = true
+# To satisfy ktlint rules, see: https://stackoverflow.com/questions/59849619/intellij-does-not-sort-kotlin-imports-according-to-ktlints-expectations
+ij_kotlin_imports_layout = *,java.**,javax.**,kotlin.**,^

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -27,5 +27,5 @@ object Versions {
 
     const val junit = "5.10.2"
     const val wiremock = "3.0.1"
-    const val mockito = "5.11.0"
+    const val mockitoKotlin = "5.3.1"
 }

--- a/kafka-connect-fitbit-source/build.gradle.kts
+++ b/kafka-connect-fitbit-source/build.gradle.kts
@@ -28,4 +28,6 @@ dependencies {
     compileOnly("com.fasterxml.jackson.core:jackson-databind")
 
     testImplementation("org.apache.kafka:connect-api:${Versions.kafka}")
+    testImplementation("com.github.tomakehurst:wiremock:${Versions.wiremock}")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:${Versions.mockitoKotlin}")
 }

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/ServiceUserRepository.kt
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/ServiceUserRepository.kt
@@ -29,6 +29,7 @@ import io.ktor.client.plugins.auth.providers.basic
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.request.headers
 import io.ktor.client.request.request
 import io.ktor.client.request.setBody
 import io.ktor.client.request.url
@@ -41,6 +42,7 @@ import io.ktor.http.URLBuilder
 import io.ktor.http.Url
 import io.ktor.http.contentLength
 import io.ktor.http.contentType
+import io.ktor.http.headers
 import io.ktor.http.isSuccess
 import io.ktor.http.takeFrom
 import io.ktor.serialization.jackson.jackson
@@ -110,6 +112,7 @@ class ServiceUserRepository : UserRepository {
         clientId: String?,
         clientSecret: String?,
     ): HttpClient = HttpClient(CIO) {
+        //TODO tokenURL can never be NULL
         if (tokenUrl != null) {
             install(Auth) {
                 clientCredentials(
@@ -201,7 +204,9 @@ class ServiceUserRepository : UserRepository {
     private suspend fun credentialCache(user: User): CachedValue<OAuth2UserCredentials> =
         credentialCaches.computeIfAbsent(user.id) {
             CachedValue(credentialCacheConfig) {
-                requestAccessToken(user) { url("users/${user.id}/token") }
+                requestAccessToken(user) {
+                    url("users/${user.id}/token")
+                }
             }
         }
 

--- a/kafka-connect-fitbit-source/src/test/java/org/radarbase/connect/rest/fitbit/user/ServiceUserRepositoryTest.kt
+++ b/kafka-connect-fitbit-source/src/test/java/org/radarbase/connect/rest/fitbit/user/ServiceUserRepositoryTest.kt
@@ -4,7 +4,6 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration
 import com.github.tomakehurst.wiremock.stubbing.Scenario
-import java.net.URL
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -14,36 +13,45 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.radarbase.connect.rest.fitbit.FitbitRestSourceConnectorConfig
+import java.net.URL
 
-internal class ServiceUserRepositoryIntegrationTest {
+internal class ServiceUserRepositoryTest {
     private val wireMockServer = WireMockServer(WireMockConfiguration.options().port(8089))
     private val serviceUserRepository = ServiceUserRepository()
     private val userId = "32"
     private val expectedToken = "placeholderAccessToken"
     private val scheduledResponse = WireMock.aResponse()
         .withHeader("Content-Length", "1000")
-        .withHeader("WWW-Authenticate", "Bearer realm=\"RADAR-base\", error=\"invalid_token\", error_description=\"No registered validator in could authenticate this token: The Token has expired on 2024-07-04T01:20:31Z., The Token has expired on 2024-07-04T01:20:31Z.\"")
+        .withHeader(
+            "WWW-Authenticate",
+            "Bearer realm=\"RADAR-base\"," +
+                " error=\"invalid_token\"," +
+                " error_description=\"No registered validator in could authenticate this token:" +
+                " The Token has expired on 2024-07-04T01:20:31Z., " +
+                "The Token has expired on 2024-07-04T01:20:31Z.\"",
+        )
         .withBody(
             "{\n" +
-                    "  \"refreshToken\": \"placeholderRefreshToken\",\n" +
-                    "  \"accessToken\": \"${expectedToken}\",\n" +
-                    "  \"expiresIn\": 3600\n" +
-                    "}"
+                "  \"refreshToken\": \"placeholderRefreshToken\",\n" +
+                "  \"accessToken\": \"${expectedToken}\",\n" +
+                "  \"expiresIn\": 3600\n" +
+                "}",
         )
         .withStatus(200)
 
-    private val path = "/users/${userId}/token"
+    private val path = "/users/$userId/token"
 
     private val mockUser: User = mock()
     private val mockConfig: FitbitRestSourceConnectorConfig = mock()
-
 
     @BeforeEach
     fun setup() {
         wireMockServer.start()
         WireMock.configureFor("localhost", 8089)
 
-        whenever(mockConfig.getFitbitUserRepositoryUrl()).doReturn(wireMockServer.baseUrl().toHttpUrlOrNull())
+        whenever(mockConfig.getFitbitUserRepositoryUrl()).doReturn(
+            wireMockServer.baseUrl().toHttpUrlOrNull(),
+        )
         whenever(mockConfig.fitbitUserRepositoryClientId).doReturn("clientId")
         whenever(mockConfig.fitbitUserRepositoryClientSecret).doReturn("clientSecret")
 
@@ -58,20 +66,24 @@ internal class ServiceUserRepositoryIntegrationTest {
 
     @Test
     fun refreshAccessTokenTokenUrlHasAuthHeader() {
-        whenever(mockConfig.getFitbitUserRepositoryTokenUrl()).doReturn(URL("http://localhost:8089/token"))
+        whenever(mockConfig.getFitbitUserRepositoryTokenUrl()).doReturn(
+            URL(
+                "http://localhost:8089/token",
+            ),
+        )
         val scheduledMPResponse = WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withBody(
                 "{\n" +
-                        "    \"access_token\": \"MyToken\",\n" +
-                        "    \"token_type\": \"bearer\",\n" +
-                        "    \"expires_in\": 899,\n" +
-                        "    \"scope\": \"MEASUREMENT.CREATE SUBJECT.READ\",\n" +
-                        "    \"iss\": \"ManagementPortal\",\n" +
-                        "    \"grant_type\": \"client_credentials\",\n" +
-                        "    \"iat\": 1720022075,\n" +
-                        "    \"jti\": \"lyOAoyUeagcCD0kUVe8HmY8d2vU\"\n" +
-                        "}"
+                    "    \"access_token\": \"MyToken\",\n" +
+                    "    \"token_type\": \"bearer\",\n" +
+                    "    \"expires_in\": 899,\n" +
+                    "    \"scope\": \"MEASUREMENT.CREATE SUBJECT.READ\",\n" +
+                    "    \"iss\": \"ManagementPortal\",\n" +
+                    "    \"grant_type\": \"client_credentials\",\n" +
+                    "    \"iat\": 1720022075,\n" +
+                    "    \"jti\": \"lyOAoyUeagcCD0kUVe8HmY8d2vU\"\n" +
+                    "}",
             )
             .withStatus(200)
 
@@ -80,19 +92,21 @@ internal class ServiceUserRepositoryIntegrationTest {
             WireMock.get(WireMock.urlEqualTo(path))
                 .inScenario("Temporary Response Scenario")
                 .whenScenarioStateIs(Scenario.STARTED)
-                .willReturn(scheduledResponse
-                    .withStatus(401))
-                .willSetStateTo("Old Response State")
+                .willReturn(
+                    scheduledResponse
+                        .withStatus(401),
+                )
+                .willSetStateTo("Old Response State"),
         )
         WireMock.stubFor(
             WireMock.post(WireMock.urlEqualTo("/token"))
-                .willReturn(scheduledMPResponse)
+                .willReturn(scheduledMPResponse),
         )
         WireMock.stubFor(
             WireMock.get(WireMock.urlEqualTo(path))
                 .inScenario("Temporary Response Scenario")
                 .whenScenarioStateIs("Old Response State")
-                .willReturn(scheduledResponse.withStatus(200))
+                .willReturn(scheduledResponse.withStatus(200)),
         )
 
         // Act
@@ -102,6 +116,9 @@ internal class ServiceUserRepositoryIntegrationTest {
         // Assert
         assertEquals(expectedToken, refreshToken)
         assertEquals(events.size, 3)
-        assert(events.first().request.headers.getHeader("Authorization").containsValue("Bearer MyToken"))
+        assert(
+            events.first().request.headers.getHeader("Authorization")
+                .containsValue("Bearer MyToken"),
+        )
     }
 }

--- a/kafka-connect-fitbit-source/src/test/java/org/radarbase/connect/rest/fitbit/user/ServiceUserRepositoryTest.kt
+++ b/kafka-connect-fitbit-source/src/test/java/org/radarbase/connect/rest/fitbit/user/ServiceUserRepositoryTest.kt
@@ -1,0 +1,107 @@
+package org.radarbase.connect.rest.fitbit.user
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.stubbing.Scenario
+import java.net.URL
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.radarbase.connect.rest.fitbit.FitbitRestSourceConnectorConfig
+
+internal class ServiceUserRepositoryIntegrationTest {
+    private val wireMockServer = WireMockServer(WireMockConfiguration.options().port(8089))
+    private val serviceUserRepository = ServiceUserRepository()
+    private val userId = "32"
+    private val expectedToken = "placeholderAccessToken"
+    private val scheduledResponse = WireMock.aResponse()
+        .withHeader("Content-Length", "1000")
+        .withHeader("WWW-Authenticate", "Bearer realm=\"RADAR-base\", error=\"invalid_token\", error_description=\"No registered validator in could authenticate this token: The Token has expired on 2024-07-04T01:20:31Z., The Token has expired on 2024-07-04T01:20:31Z.\"")
+        .withBody(
+            "{\n" +
+                    "  \"refreshToken\": \"placeholderRefreshToken\",\n" +
+                    "  \"accessToken\": \"${expectedToken}\",\n" +
+                    "  \"expiresIn\": 3600\n" +
+                    "}"
+        )
+        .withStatus(200)
+
+    private val path = "/users/${userId}/token"
+
+    private val mockUser: User = mock()
+    private val mockConfig: FitbitRestSourceConnectorConfig = mock()
+
+
+    @BeforeEach
+    fun setup() {
+        wireMockServer.start()
+        WireMock.configureFor("localhost", 8089)
+
+        whenever(mockConfig.getFitbitUserRepositoryUrl()).doReturn(wireMockServer.baseUrl().toHttpUrlOrNull())
+        whenever(mockConfig.fitbitUserRepositoryClientId).doReturn("clientId")
+        whenever(mockConfig.fitbitUserRepositoryClientSecret).doReturn("clientSecret")
+
+        whenever(mockUser.isAuthorized).doReturn(true)
+        whenever(mockUser.id).doReturn(userId)
+    }
+
+    @AfterEach
+    fun teardown() {
+        wireMockServer.stop()
+    }
+
+    @Test
+    fun refreshAccessTokenTokenUrlHasAuthHeader() {
+        whenever(mockConfig.getFitbitUserRepositoryTokenUrl()).doReturn(URL("http://localhost:8089/token"))
+        val scheduledMPResponse = WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(
+                "{\n" +
+                        "    \"access_token\": \"MyToken\",\n" +
+                        "    \"token_type\": \"bearer\",\n" +
+                        "    \"expires_in\": 899,\n" +
+                        "    \"scope\": \"MEASUREMENT.CREATE SUBJECT.READ\",\n" +
+                        "    \"iss\": \"ManagementPortal\",\n" +
+                        "    \"grant_type\": \"client_credentials\",\n" +
+                        "    \"iat\": 1720022075,\n" +
+                        "    \"jti\": \"lyOAoyUeagcCD0kUVe8HmY8d2vU\"\n" +
+                        "}"
+            )
+            .withStatus(200)
+
+        serviceUserRepository.initialize(mockConfig)
+        WireMock.stubFor(
+            WireMock.get(WireMock.urlEqualTo(path))
+                .inScenario("Temporary Response Scenario")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(scheduledResponse
+                    .withStatus(401))
+                .willSetStateTo("Old Response State")
+        )
+        WireMock.stubFor(
+            WireMock.post(WireMock.urlEqualTo("/token"))
+                .willReturn(scheduledMPResponse)
+        )
+        WireMock.stubFor(
+            WireMock.get(WireMock.urlEqualTo(path))
+                .inScenario("Temporary Response Scenario")
+                .whenScenarioStateIs("Old Response State")
+                .willReturn(scheduledResponse.withStatus(200))
+        )
+
+        // Act
+        val refreshToken = serviceUserRepository.getAccessToken(mockUser)
+        val events = wireMockServer.serveEvents.serveEvents
+
+        // Assert
+        assertEquals(expectedToken, refreshToken)
+        assertEquals(events.size, 3)
+        assert(events.first().request.headers.getHeader("Authorization").containsValue("Bearer MyToken"))
+    }
+}

--- a/kafka-connect-rest-source/build.gradle.kts
+++ b/kafka-connect-rest-source/build.gradle.kts
@@ -7,8 +7,6 @@ dependencies {
     compileOnly("org.apache.kafka:connect-api:${Versions.kafka}")
     compileOnly("org.slf4j:slf4j-api:${Versions.slf4j}")
 
-    testImplementation("org.mockito:mockito-core:${Versions.mockito}")
     testImplementation("com.github.tomakehurst:wiremock:${Versions.wiremock}")
-
     testImplementation("org.apache.kafka:connect-api:${Versions.kafka}")
 }


### PR DESCRIPTION
We had issues with failing requests due to malformed www-authenticate header. the issue is resolved in rest-source-backend.

This PR adds an integration test that tests the response to an invalid token.