### PR TITLE
update too many req cooldown handling

### DIFF
--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/FitbitRestSourceConnectorConfig.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/FitbitRestSourceConnectorConfig.java
@@ -259,6 +259,11 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
   private static final String FITBIT_TOO_MANY_REQUESTS_COOLDOWN_DISPLAY = "Too many requests cooldown (s)";
   private static final int FITBIT_TOO_MANY_REQUESTS_COOLDOWN_DEFAULT = 3600; // 1 hour
 
+  public static final String FITBIT_COOLDOWN_STRATEGY_CONFIG = "fitbit.cooldown.strategy";
+  private static final String FITBIT_COOLDOWN_STRATEGY_DOC = "Strategy for handling too many requests cooldown. Options: ROLLING_WINDOW, TOP_OF_HOUR";
+  private static final String FITBIT_COOLDOWN_STRATEGY_DISPLAY = "Cooldown strategy";
+  private static final String FITBIT_COOLDOWN_STRATEGY_DEFAULT = "ROLLING_WINDOW";
+
   private UserRepository userRepository;
   private final Headers clientCredentials;
 
@@ -703,6 +708,16 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
             ++orderInGroup,
             Width.SHORT,
             FITBIT_TOO_MANY_REQUESTS_COOLDOWN_DISPLAY)
+
+        .define(FITBIT_COOLDOWN_STRATEGY_CONFIG,
+            Type.STRING,
+            FITBIT_COOLDOWN_STRATEGY_DEFAULT,
+            Importance.MEDIUM,
+            FITBIT_COOLDOWN_STRATEGY_DOC,
+            group,
+            ++orderInGroup,
+            Width.SHORT,
+            FITBIT_COOLDOWN_STRATEGY_DISPLAY)
         ;
   }
 
@@ -909,5 +924,13 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
 
   public int getForbiddenBackoff() {
     return getInt(FITBIT_FORBIDDEN_BACKOFF_CONFIG);
+  }
+
+  public String getCooldownStrategy() {
+    String value = getString(FITBIT_COOLDOWN_STRATEGY_CONFIG);
+    if (!value.equalsIgnoreCase("ROLLING_WINDOW") && !value.equalsIgnoreCase("TOP_OF_HOUR")) {
+      throw new ConfigException(FITBIT_COOLDOWN_STRATEGY_CONFIG, value, "Invalid cooldown strategy. Must be either ROLLING_WINDOW or TOP_OF_HOUR.");
+    }
+    return value;
   }
 }

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/FitbitRestSourceConnectorConfig.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/FitbitRestSourceConnectorConfig.java
@@ -254,6 +254,10 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
   private static final String FITBIT_FORBIDDEN_BACKOFF_DISPLAY = "Forbidden backoff time (s)";
   private static final int FITBIT_FORBIDDEN_BACKOFF_DEFAULT = 86400; // 24 hours
 
+  public static final String FITBIT_TOO_MANY_REQUESTS_COOLDOWN_CONFIG = "fitbit.too.many.requests.cooldown.s";
+  private static final String FITBIT_TOO_MANY_REQUESTS_COOLDOWN_DOC = "Cooldown time in seconds after receiving too many requests (429) response.";
+  private static final String FITBIT_TOO_MANY_REQUESTS_COOLDOWN_DISPLAY = "Too many requests cooldown (s)";
+  private static final int FITBIT_TOO_MANY_REQUESTS_COOLDOWN_DEFAULT = 3600; // 1 hour
 
   private UserRepository userRepository;
   private final Headers clientCredentials;
@@ -689,6 +693,16 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
             ++orderInGroup,
             Width.SHORT,
             FITBIT_FORBIDDEN_BACKOFF_DISPLAY)
+
+        .define(FITBIT_TOO_MANY_REQUESTS_COOLDOWN_CONFIG,
+            Type.INT,
+            FITBIT_TOO_MANY_REQUESTS_COOLDOWN_DEFAULT,
+            Importance.MEDIUM,
+            FITBIT_TOO_MANY_REQUESTS_COOLDOWN_DOC,
+            group,
+            ++orderInGroup,
+            Width.SHORT,
+            FITBIT_TOO_MANY_REQUESTS_COOLDOWN_DISPLAY)
         ;
   }
 
@@ -849,7 +863,7 @@ public class FitbitRestSourceConnectorConfig extends RestSourceConnectorConfig {
   }
 
   public Duration getTooManyRequestsCooldownInterval() {
-    return Duration.ofHours(1);
+    return Duration.ofSeconds(getInt(FITBIT_TOO_MANY_REQUESTS_COOLDOWN_CONFIG));
   }
 
   public String getFitbitIntradayCaloriesTopic() {


### PR DESCRIPTION
[According to this](https://dev.fitbit.com/build/reference/web-api/troubleshooting-guide/error-messages/#429-too-many-requests), the rate limit is reset at the top of the hour, unlike the current implementation - using a rolling window from when the error is received.

```
Returned if the application has reached the rate limit for a specific user. The rate limit will be reset at the top of the hour.
```

This PR adds a strategy to calculate cooldown/backoff time based on top of the current hour. But the legacy code is till present and is the default. Configuration can be dones as follows-

```properties
# Use top-of-hour strategy (recommended for Fitbit)
fitbit.cooldown.strategy=TOP_OF_HOUR

# Use rolling window strategy (legacy behavior)
fitbit.cooldown.strategy=ROLLING_WINDOW
fitbit.too.many.requests.cooldown.s=3600
```

This PR also makes the backoff configurable. This was hardcoded to 1hr by default. Though i think we don't need to update this dynamically since rate limit is by the hour (150 req per hour), but would be good for testing and debugging. 