### PR TITLE
fix: isStale call to fitbit connector respects external cache configuration

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -21,7 +21,7 @@ object Versions {
 
     const val okhttp = "4.12.0"
 
-    const val firebaseAdmin = "9.4.0"
+    const val firebaseAdmin = "9.6.0"
     const val radarSchemas = "0.8.14"
     const val ktor = "2.3.10"
 
@@ -29,5 +29,5 @@ object Versions {
     const val wiremock = "3.0.1"
     const val mockito = "5.11.0"
 
-    const val nettyVersion = "4.1.118.Final"
+    const val nettyVersion = "4.1.125.Final"
 }

--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/ServiceUserRepository.kt
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/user/ServiceUserRepository.kt
@@ -61,7 +61,6 @@ import java.io.IOException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.stream.Stream
 import kotlin.time.Duration.Companion.days
-import kotlin.time.Duration.Companion.hours
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toKotlinDuration
@@ -235,7 +234,7 @@ class ServiceUserRepository : UserRepository {
         }
 
     override fun hasPendingUpdates(): Boolean = runBlocking(Dispatchers.Default) {
-        userCache.isStale(1.hours)
+        userCache.isStale()
     }
 
     @Throws(IOException::class)


### PR DESCRIPTION
# Problem
A hard coded isStable call with a timewindow of 1hr was introduced. This caused the e2e tests that use a short timewindow to fail.

# Solution
This PR will remove this 1hr isStale call and makes the call listen to the cache duration specified in the external config of the service.