### PR TITLE
fix/resting-heart-rate-offset

### DIFF
--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitPollingRoute.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitPollingRoute.java
@@ -164,6 +164,9 @@ public abstract class FitbitPollingRoute implements PollingRequestRoute {
     lastPollPerUser.put(((FitbitRestRequest) request).getUser().getId(), lastPoll);
     FitbitRestRequest fitbitRequest = (FitbitRestRequest) request;
     Instant endOffset = fitbitRequest.getDateRange().end().toInstant();
+    // When having polled a date range for a route for HISTORICAL_TIME_DAYS days and
+    // the response has no data, consider this data not to exist by considering
+    // the end of the date range as the last successful data retrieval.
     if (DAYS.between(endOffset, lastPoll) >= HISTORICAL_TIME_DAYS) {
       String key = fitbitRequest.getUser().getVersionedId();
       offsets.put(key, endOffset);


### PR DESCRIPTION
# Problem
On the CONNECT project we experienced problems with retrieval of Fitbit resting heart rate (RHR) data. The Fitbit connector would every day download the same RHR datum that lies far in the past.

# Analysis
As far as I can see there is a problem with determining the date of the next RHR datum. RHR is queried at the resolution of  a single day:

```java
    return baseUrl + "/1/user/%s/activities/heart/date/%s/1d.json?timezone=UTC";
```

The existing logic will take the date of the last successful RHR datum, add one second, round this to days and use the resulting day to query the next RHR datum:

```java
    ZonedDateTime startDate = this.getOffset(user).plus(ONE_SECOND)
        .atZone(UTC)
        .truncatedTo(SECONDS);
    return Stream.of(newRequest(user, new DateRange(startDate, ZonedDateTime.now(UTC)),
        user.getExternalUserId(), DATE_FORMAT.format(startDate)));
```

This will effectively result in the same day being queried over and over since this will always resolve to the same day offset of the last successfull datum.

# Solution
This PR will correct the offset for the next datum by progressing the `startDate` with one day instead of one second.