### PR TITLE
Filter Intraday Heart Rate data by request date range

### DIFF
--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitIntradayHeartRateRoute.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitIntradayHeartRateRoute.java
@@ -46,8 +46,8 @@ public class FitbitIntradayHeartRateRoute extends FitbitPollingRoute {
     return startDateGenerator(getOffset(user).plus(ONE_SECOND).truncatedTo(SECONDS))
         .map(dateRange -> newRequest(user, dateRange,
             user.getExternalUserId(), DATE_FORMAT.format(dateRange.start()),
-            ISO_LOCAL_TIME.format(dateRange.start()),
-            ISO_LOCAL_TIME.format(dateRange.end().truncatedTo(SECONDS))));
+            TIME_FORMAT.format(dateRange.start()),
+            TIME_FORMAT.format(dateRange.end().truncatedTo(SECONDS))));
   }
 
   @Override


### PR DESCRIPTION
Fixes #193 
This PR corrects the time format used in formatting the URL for Fitbit Intraday Heart Rate data. Use of HH:mm:ss format instead of HH:mm resulted in incorrect data points appended to the observations (see linked Issue #193). 