### PR TITLE
Enable Maven Central snapshots and release publishing for oura-library and google-health-library

### DIFF
--- a/.github/workflows/publish-snapshots.yml
+++ b/.github/workflows/publish-snapshots.yml
@@ -1,0 +1,40 @@
+name: Publish snapshots
+
+on:
+  push:
+    branches: [ dev ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Assert SNAPSHOT version
+        run: |
+          ./gradlew properties --no-daemon -q | grep 'version: .*-SNAPSHOT'
+
+      - name: Import GPG signing key
+        run: |
+          echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}" | gpg --batch --import
+          gpg --list-secret-keys --keyid-format LONG
+
+      - name: Publish to Sonatype snapshots
+        env:
+          OSSRH_USER: ${{ secrets.OSSRH_USER_TOKEN_ID }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_USER_TOKEN_SECRET }}
+        run: >-
+          ./gradlew
+          -Psigning.gnupg.keyName=${{ secrets.OSSRH_GPG_SECRET_KEY_NAME }}
+          -Psigning.gnupg.executable=gpg
+          -Psigning.gnupg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
+          publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,45 @@ jobs:
           files: '*/build/libs/*'
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+  publish-jars:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Assert release (non-SNAPSHOT) version
+        run: |
+          if ./gradlew properties --no-daemon -q | grep -q 'version: .*-SNAPSHOT'; then
+            echo "Refusing to release: project version is still -SNAPSHOT" >&2
+            exit 1
+          fi
+
+      - name: Import GPG signing key
+        run: |
+          echo -e "${{ secrets.OSSRH_GPG_SECRET_KEY }}" | gpg --batch --import
+          gpg --list-secret-keys --keyid-format LONG
+
+      - name: Publish and close staging repository
+        env:
+          OSSRH_USER: ${{ secrets.OSSRH_USER_TOKEN_ID }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_USER_TOKEN_SECRET }}
+        run: >-
+          ./gradlew
+          -Psigning.gnupg.keyName=${{ secrets.OSSRH_GPG_SECRET_KEY_NAME }}
+          -Psigning.gnupg.executable=gpg
+          -Psigning.gnupg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
+          publish closeAndReleaseSonatypeStagingRepository
+
   prepare-matrix:
     name: Prepare Matrix Output
     runs-on: ubuntu-latest

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ radarRootProject {
 val githubRepoName = "RADAR-base/RADAR-REST-Connector"
 val githubProjectUrl = "https://github.com/$githubRepoName"
 
-val publishedSubprojects = setOf("oura-library", "google-health-library")
+val publishedSubprojects = setOf("google-health-library")
 
 subprojects {
     apply(plugin = "org.radarbase.radar-kotlin")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,11 @@
 import org.radarbase.gradle.plugin.radarKotlin
+import org.radarbase.gradle.plugin.radarPublishing
 
 plugins {
     alias(libs.plugins.radar.root.project)
     alias(libs.plugins.radar.dependency.management)
     alias(libs.plugins.radar.kotlin) apply false
+    alias(libs.plugins.radar.publishing) apply false
 }
 
 repositories {
@@ -17,8 +19,36 @@ radarRootProject {
     gradleVersion.set(libs.versions.gradle)
 }
 
+val githubRepoName = "RADAR-base/RADAR-REST-Connector"
+val githubProjectUrl = "https://github.com/$githubRepoName"
+
+val publishedSubprojects = setOf("oura-library", "google-health-library")
+
 subprojects {
     apply(plugin = "org.radarbase.radar-kotlin")
+
+    if (name in publishedSubprojects) {
+        apply(plugin = "org.radarbase.radar-publishing")
+        radarPublishing {
+            githubUrl.set(githubProjectUrl)
+            developers {
+                developer {
+                    id.set("yatharthranjan")
+                    name.set("Yatharth Ranjan")
+                    email.set("yatharth.ranjan@kcl.ac.uk")
+                    organization.set("King's College London")
+                    id.set("mpgxvii")
+                    name.set("Pauline Conde")
+                    email.set("mpgxvii@gmail.com")
+                    organization.set("King's College London")
+                    id.set("this-Aditya")
+                    name.set("Aditya Mishra")
+                    email.set("aditya.mishra@kcl.ac.uk")
+                    organization.set("King's College London")
+                }
+            }
+        }
+    }
 
     // --- Vulnerability fixes start ---
     dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,10 +37,14 @@ subprojects {
                     name.set("Yatharth Ranjan")
                     email.set("yatharth.ranjan@kcl.ac.uk")
                     organization.set("King's College London")
+                }
+                developer {
                     id.set("mpgxvii")
                     name.set("Pauline Conde")
                     email.set("mpgxvii@gmail.com")
                     organization.set("King's College London")
+                }
+                developer {
                     id.set("this-Aditya")
                     name.set("Aditya Mishra")
                     email.set("aditya.mishra@kcl.ac.uk")

--- a/google-health-library/build.gradle
+++ b/google-health-library/build.gradle
@@ -1,12 +1,4 @@
-
-group = 'org.radarbase'
-version = '0.0.1'
-
-apply plugin: 'maven-publish'
-
-repositories {
-    mavenCentral()
-}
+description = "Google Health library with utility components to be used in RADAR-Pushendpoint"
 
 dependencies {
     implementation libs.kotlin.stdlib
@@ -26,17 +18,4 @@ dependencies {
     testImplementation libs.kotlin.test
 
     testImplementation libs.kotlin.test.junit
-}
-
-project.afterEvaluate {
-    publishing {
-        publications {
-            library(MavenPublication) {
-                setGroupId "$group"
-                setArtifactId "google-health-library"
-                version "$version"
-                from components.java
-            }
-        }
-    }
 }

--- a/google-health-library/build.gradle
+++ b/google-health-library/build.gradle
@@ -1,3 +1,5 @@
+description = "Google Health library with utility components to be used in RADAR-Pushendpoint"
+
 dependencies {
     implementation libs.kotlin.stdlib
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-project = "0.7.3-SNAPSHOT"
+project = "0.7.6-SNAPSHOT"
 gradle = "8.14"
 kotlin = "1.9.24"
 radarCommons = "1.2.6"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ sentryOpenTelemetryAgent = "8.36.0"
 # @pin Upgrade to 5.x.x requires kotlin v2 minimum
 okhttp = "4.12.0"
 firebaseAdmin = "9.8.0"
-radarSchemas = "0.8.16"
+radarSchemas = "0.8.18"
 # @pin Upgrade to 3.x.x requires kotlin v2 minimum
 ktor = "2.3.13"
 wiremock = "3.0.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-project = "0.7.3"
+project = "0.7.3-SNAPSHOT"
 gradle = "8.14"
 kotlin = "1.9.24"
 radarCommons = "1.2.6"
@@ -60,3 +60,4 @@ kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version
 radar-root-project = { id = "org.radarbase.radar-root-project", version.ref = "radarCommons" }
 radar-dependency-management = { id = "org.radarbase.radar-dependency-management", version.ref = "radarCommons" }
 radar-kotlin = { id = "org.radarbase.radar-kotlin", version.ref = "radarCommons" }
+radar-publishing = { id = "org.radarbase.radar-publishing", version.ref = "radarCommons" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-project = "0.7.3"
+project = "0.7.5"
 gradle = "8.14"
 kotlin = "1.9.24"
 radarCommons = "1.2.6"

--- a/oura-library/build.gradle
+++ b/oura-library/build.gradle
@@ -1,3 +1,5 @@
+description = "Library for converting Oura data into RADAR-base Avro records"
+
 dependencies {
     implementation libs.kotlin.stdlib
 

--- a/oura-library/build.gradle
+++ b/oura-library/build.gradle
@@ -1,17 +1,4 @@
-
-group = 'org.radarbase'
-version = '0.0.1'
-
-apply plugin: 'maven-publish'
-
-repositories {
-    // Use jcenter for resolving dependencies.
-    // You can declare any Maven/Ivy/file repository here.
-    mavenCentral()
-}
-
 dependencies {
-    // Use the Kotlin JDK 8 standard library.
     implementation libs.kotlin.stdlib
 
     implementation libs.okhttp
@@ -26,22 +13,7 @@ dependencies {
 
     implementation libs.jackson.datatype.jsr310
 
-    // Use the Kotlin test library.
     testImplementation libs.kotlin.test
 
-    // Use the Kotlin JUnit integration.
     testImplementation libs.kotlin.test.junit
-}
-
-project.afterEvaluate {
-    publishing {
-        publications {
-            library(MavenPublication) {
-                setGroupId "$group"
-                setArtifactId "oura-library"
-                version "$version"
-                from components.java
-            }
-        }
-    }
 }


### PR DESCRIPTION
 Applies the radar-publishing plugin to oura-library and google-health-library so both produce signed jars. Pushes to dev
 publish `-SNAPSHOT` artifacts via a new `publish-snapshots.yml` workflow, and a publish-jars job in `release.yml` promotes signed releases to Maven Central when a gitHub release is published
