### PR TITLE
fix: historic lookback for resting heart rate data

### DIFF
--- a/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitRestingHeartRateRoute.java
+++ b/kafka-connect-fitbit-source/src/main/java/org/radarbase/connect/rest/fitbit/route/FitbitRestingHeartRateRoute.java
@@ -51,10 +51,8 @@ public class FitbitRestingHeartRateRoute extends FitbitPollingRoute {
     ZonedDateTime startDate = this.getOffset(user).plus(ONE_DAY)
         .atZone(UTC)
         .truncatedTo(DAYS);
-    // Note: the date range of startDate to now() is not correct, but will ensure that in case of empty
-    // results, the HISTORICAL_TIME_DAYS retry inactivation in requestEmpty() of FitbitPollingRoute.java
-    // will never be used.
-    return Stream.of(newRequest(user, new DateRange(startDate, ZonedDateTime.now(UTC)),
+    ZonedDateTime endDate = startDate.minus(ONE_NANO);
+    return Stream.of(newRequest(user, new DateRange(startDate, endDate),
         user.getExternalUserId(), DATE_FORMAT.format(startDate)));
   }
 


### PR DESCRIPTION
# Background
The historic lookback mechanism ensures that after a certain timeperiod (14 days by default) a missing datum will be considered to be never present. After this period, the datum will never be queried again.

# Problem
For Fitbit Resting Heart Rate this mechanism was never invoked. Instead of passing the end date of the current request to the underlying code, NOW is always passed. This ensures the underlying code never considers the missing datum to expire. 

# Solution
Inline with other FitbitRoute classes the end of the current request is passed to the underlying code.